### PR TITLE
Postpone initial API call until 30 seconds after startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,14 +29,14 @@ export default class GitlabIssuesPlugin extends Plugin {
 		if (this.settings.showIcon)
 		{
 			// Ensure we did not already add an icon
-			if (!this.iconAdded) 
+			if (!this.iconAdded)
 			{
 				addIcon("gitlab", gitlabIcon);
 				this.addRibbonIcon('gitlab', 'Gitlab Issues', (evt: MouseEvent) => {
 					this.fetchFromGitlab();
 				});
 				this.iconAdded = true;
-			}			
+			}
 		}
 	}
 
@@ -52,14 +52,14 @@ export default class GitlabIssuesPlugin extends Plugin {
 
 	private refreshIssuesAtStartup() {
 		// Clear existing startup timeout
-		if (this.startupTimeout) {			
+		if (this.startupTimeout) {
 			// Not sure if this is the correct way to clear the timeout
-			// as it was created through Obsidian's API			
-			window.clearInterval(this.startupTimeout);			
-		}		
+			// as it was created through Obsidian's API
+			window.clearInterval(this.startupTimeout);
+		}
 		this.startupTimeout = this.registerInterval(window.setTimeout(() => {
 			this.fetchFromGitlab();
-		}, 5 * 1000)); // after 5 seconds
+		}, 30 * 1000)); // after 30 seconds
 	}
 
 	private scheduleAutomaticRefresh() {


### PR DESCRIPTION
On mobile devices, Obsidian takes a few seconds to start up. We do not want to add to this load with a call to the Gitlab API.

Therefore, increase the startup delay from 5 seconds to 30 seconds, so that it can be handled once all the application start jobs have finished.