### PR TITLE
Retrieve paginated response from API and allow project specific URLs

### DIFF
--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -2,19 +2,32 @@ import {requestUrl, RequestUrlParam, RequestUrlResponse} from 'obsidian';
 
 export default class GitlabApi {
 
-	static load<T>(url: string, gitlabToken: string): Promise<T> {
+	static load<T>(url: string, gitlabToken: string, page?: string): Promise<T> {
 
 		const headers = { 'PRIVATE-TOKEN': gitlabToken };
+        let req_url: string;
 
-		const params: RequestUrlParam = { url: url, headers: headers };
-
+        if (!!page) {
+            req_url = `${url}&page=${page}`;
+        } else {
+            req_url = url;
+        }
+        
+		const params: RequestUrlParam = { url: req_url, headers: headers };
+        
 		return requestUrl(params)
 			.then((response: RequestUrlResponse) => {
 				if (response.status !== 200) {
 					throw new Error(response.text);
 				}
 
-				return response.json as Promise<T>;
-			});
+                if ("x-next-page" in response.headers && response.headers["x-next-page"] != "") {
+                    return GitlabApi.load(url, gitlabToken, response.headers["x-next-page"]).then((j) => {
+				        return response.json.concat(j) as Promise<T>;
+                    }) as Promise<T>;
+                } else {
+                    return response.json as Promise<T>;
+                }
+            });
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,7 +19,12 @@ export const DEFAULT_SETTINGS: GitlabIssuesSettings = {
 	filter: 'due_date=month',
 	showIcon: false,
 	gitlabApiUrl(): string {
-		return `${this.gitlabUrl}/api/v4`;
+        if (this.gitlabUrl.indexOf('/api/') != -1) {
+            // Full path to API (might be a project specific URL
+		    return this.gitlabUrl;
+        } else {
+		    return `${this.gitlabUrl}/api/v4`;
+        }
 	}
 };
 


### PR DESCRIPTION
Retrieves all the pages of issues if a paginated response is returned.
Also allows a project specific URL to be used for the GitLab URL.